### PR TITLE
#50 Fix module field in package.json definitions

### DIFF
--- a/.changeset/two-comics-kiss.md
+++ b/.changeset/two-comics-kiss.md
@@ -1,0 +1,7 @@
+---
+"@croz/nrich-form-configuration-core": patch
+"@croz/nrich-notification-core": patch
+"@croz/nrich-notification-mui": patch
+---
+
+#50 Fix module field in package.json definitions

--- a/libs/form-configuration/core/package.json
+++ b/libs/form-configuration/core/package.json
@@ -37,7 +37,7 @@
     "zustand"
   ],
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"

--- a/libs/notification/core/package.json
+++ b/libs/notification/core/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"

--- a/libs/notification/mui/package.json
+++ b/libs/notification/mui/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "peerDependencies": {
     "@croz/nrich-notification-core": "^1.0.0",
     "@mui/material": "^5.0.0",


### PR DESCRIPTION
## Basic information

* nrich-frontend version: 1.0.9
* Module: project

## Additional information

Vite, Typescript

## Description

### Summary

Fixed wrong module declaration in package.json files

### Related issue

Solves #50 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist


- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass.
