### PR TITLE
#52 Add generic type to useYupFormConfiguration hook

### DIFF
--- a/.changeset/spotty-points-travel.md
+++ b/.changeset/spotty-points-travel.md
@@ -1,0 +1,5 @@
+---
+"@croz/nrich-form-configuration-core": minor
+---
+
+Added possibility to define generic type when using `useYupFormConfiguration`

--- a/libs/form-configuration/core/README.md
+++ b/libs/form-configuration/core/README.md
@@ -33,10 +33,13 @@ import React, { useState } from "react";
 import { useYupFormConfiguration } from "@croz/nrich-form-configuration-core";
 import { Form, Formik } from "formik";
 
+type CreateForm = {
+  /* fields of the form */
+}
 
 export const SomeFormComponent = () => {
   const [formValues, setFormValues] = useState({});
-  const validationSchema = useYupFormConfiguration('user.create-form');
+  const validationSchema = useYupFormConfiguration<CreateForm>('user.create-form');
 
   return (
     <Formik
@@ -44,12 +47,13 @@ export const SomeFormComponent = () => {
       onSubmit={(values) => setFormValues(values)}
     >
       <Form>
-        { /* Rest of the form */ }
+        { /* Rest of the form */}
       </Form>
     </Formik>
   );
 };
 ```
+
 *NOTE: Formik is used just as an example, you can use any form lib compatible with `yup`.*
 
 ## Details
@@ -63,7 +67,6 @@ export const SomeFormComponent = () => {
 | url                           | Backend form configuration path                                       | no       | `/nrich/form/configuration` |
 | requestOptionsResolver        | Function that creates options for the initial fetch call to backend   | no       | none                        |
 | additionalValidatorConverters | List of `ValidatorConverter`s used to allow custom validations        | no       | none                        |
-
 
 ### Registering and using custom validations
 

--- a/libs/form-configuration/core/src/api/form-configuration-types.ts
+++ b/libs/form-configuration/core/src/api/form-configuration-types.ts
@@ -31,7 +31,7 @@ export interface FormConfiguration {
 
 }
 
-export interface FormYupConfiguration {
+export interface FormYupConfiguration<T extends Record<string, never> = any> {
 
   /**
    * Registered form id for this form configuration.
@@ -41,7 +41,7 @@ export interface FormYupConfiguration {
   /**
    * List of yup ObjectSchema instances holding property configuration for each property defined in the class that form id was mapped to.
    */
-  yupSchema: yup.ObjectSchema<any>;
+  yupSchema: yup.ObjectSchema<T>;
 
 }
 

--- a/libs/form-configuration/core/src/hook/use-form-configuration.ts
+++ b/libs/form-configuration/core/src/hook/use-form-configuration.ts
@@ -15,6 +15,8 @@
  *
  */
 
+import { ObjectSchema } from "yup";
+
 import { FormYupConfiguration } from "../api";
 import { useFormConfigurationStore } from "../store";
 
@@ -80,7 +82,7 @@ export const useFormConfiguration: UseFormConfiguration = () => {
  *
  * @returns Mapped Yup configuration from the form configuration identified by the form id, or undefined if no matching form configuration is found.
  */
-export const useYupFormConfiguration = (formId: string) => {
+export const useYupFormConfiguration = <T extends Record<string, any> = any>(formId: string) => {
   const { formYupConfigurations } = useFormConfiguration();
 
   const searchedFormConfiguration = formYupConfigurations.find((formYupConfiguration) => formYupConfiguration.formId === formId);
@@ -89,5 +91,5 @@ export const useYupFormConfiguration = (formId: string) => {
     return undefined;
   }
 
-  return searchedFormConfiguration.yupSchema;
+  return searchedFormConfiguration.yupSchema as ObjectSchema<T>;
 };

--- a/libs/form-configuration/core/test/hook/use-form-configuration.test.ts
+++ b/libs/form-configuration/core/test/hook/use-form-configuration.test.ts
@@ -104,4 +104,20 @@ describe("@croz/nrich-form-configuration-core/use-form-configuration", () => {
     // then
     expect(result.current).toEqual(undefined);
   });
+
+  it("should compile and return yup object when used with generic", () => {
+    // given
+    type RegistrationForm = {
+      username: string,
+      password: string,
+      oib: number,
+    };
+
+    // when
+    const { formId } = mockFormYupConfigurations[0];
+    const { result } = renderHook(() => useYupFormConfiguration<RegistrationForm>(formId));
+
+    // then
+    expect(result.current).toMatchObject(mockFormYupConfigurations[0].yupSchema);
+  });
 });


### PR DESCRIPTION
## Basic information

* nrich-frontend version: 2.0.0
* Module: form-configuration-core


## Description

### Summary

Added possibility to define generic type when using useYupFormConfiguration

### Related issue

Closes #52 

## Types of changes


- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
