### PR TITLE
Feature ignore non json responses in xhr notification interceptor

### DIFF
--- a/.changeset/strong-baboons-impress.md
+++ b/.changeset/strong-baboons-impress.md
@@ -1,0 +1,5 @@
+---
+"@croz/nrich-notification-core": patch
+---
+
+Update xhrNotificationInterceptor to ignore non-json responses

--- a/libs/notification/core/src/interceptor/xhr-notification-interceptor.ts
+++ b/libs/notification/core/src/interceptor/xhr-notification-interceptor.ts
@@ -31,9 +31,14 @@ export const xhrNotificationInterceptor = () => {
     // eslint-disable-next-line func-names
     this.addEventListener("readystatechange", function () {
       if (this.readyState === 4) {
-        const body = JSON.parse(this.responseText);
-        if (isNotificationResponse(body)) {
-          useNotificationStore.getState().add(body.notification);
+        try {
+          const body = JSON.parse(this.responseText);
+          if (isNotificationResponse(body)) {
+            useNotificationStore.getState().add(body.notification);
+          }
+        }
+        catch (e) {
+          // ignore non-json responses
         }
       }
     }, false);

--- a/libs/notification/core/test/interceptor/xhr-notification-interceptor.test.ts
+++ b/libs/notification/core/test/interceptor/xhr-notification-interceptor.test.ts
@@ -65,4 +65,19 @@ describe("@croz/nrich-notification-core/xhr-notification-interceptor", () => {
     // then
     expect(notificationState.notifications).toHaveLength(0);
   });
+
+  it("should ignore responses with plain text", async () => {
+    // when
+    const response = await axios.get("/with-plain-text");
+
+    // then
+    expect(response).toBeDefined();
+    expect(response.data).toMatch("plain text");
+
+    // and when
+    const notificationState = useNotificationStore.getState();
+
+    // then
+    expect(notificationState.notifications).toHaveLength(0);
+  });
 });

--- a/libs/notification/core/test/testutil/setup-notification-server.ts
+++ b/libs/notification/core/test/testutil/setup-notification-server.ts
@@ -35,4 +35,8 @@ export const setupNotificationServer = (): SetupServerApi => setupServer(
   rest.get("/without-notification", (_, response, context) => response(context.json(
     { success: true },
   ))),
+
+  rest.get("/with-plain-text", (_, response, context) => response(context.text(
+    "plain text",
+  ))),
 );


### PR DESCRIPTION
## Basic information

* @croz/nrich-notification-core version: v1.1.1
* Module:
  <!-- Please, include name(s) of relevant nrich-frontend's module(s). If not related to any specific module, specify "project" instead. -->
  * @croz/nrich-notification-core

## Description
The xhrNotificationInterceptor throws an error when dealing with non-JSON responses.

### Summary
Update xhrNotificationInterceptor to ignore non-JSON responses

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
