### PR TITLE
Feature upgrade zustand and upgrade imports

### DIFF
--- a/.changeset/afraid-bikes-reflect.md
+++ b/.changeset/afraid-bikes-reflect.md
@@ -1,0 +1,6 @@
+---
+"@croz/nrich-form-configuration-core": patch
+"@croz/nrich-notification-core": patch
+---
+
+Upgrade zustand lib and its import statements to non-deprecated sytax

--- a/libs/form-configuration/core/package.json
+++ b/libs/form-configuration/core/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/croz-ltd/nrich-frontend/issues",
   "dependencies": {
     "yup": "^0.32.11",
-    "zustand": "^4.1.4"
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@croz/nrich-jest-config": "*",

--- a/libs/form-configuration/core/src/store/form-configuration-store.ts
+++ b/libs/form-configuration/core/src/store/form-configuration-store.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import create from "zustand";
+import { create } from "zustand";
 
 import { FormYupConfiguration } from "../api";
 

--- a/libs/notification/core/package.json
+++ b/libs/notification/core/package.json
@@ -5,7 +5,7 @@
   "author": "CROZ",
   "bugs": "https://github.com/croz-ltd/nrich-frontend/issues",
   "dependencies": {
-    "zustand": "^4.1.4"
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@croz/nrich-jest-config": "*",

--- a/libs/notification/core/src/store/notification-store.ts
+++ b/libs/notification/core/src/store/notification-store.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import create from "zustand";
+import { create } from "zustand";
 
 import { Notification } from "../api";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,7 +709,7 @@ __metadata:
     tsup: ^6.5.0
     whatwg-fetch: ^3.6.2
     yup: ^0.32.11
-    zustand: ^4.1.4
+    zustand: ^4.4.7
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -746,7 +746,7 @@ __metadata:
     react-dom: ^18.1.0
     tsup: ^6.5.0
     whatwg-fetch: ^3.6.2
-    zustand: ^4.1.4
+    zustand: ^4.4.7
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
@@ -9236,19 +9236,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.1.4":
-  version: 4.1.4
-  resolution: "zustand@npm:4.1.4"
+"zustand@npm:^4.4.7":
+  version: 4.4.7
+  resolution: "zustand@npm:4.4.7"
   dependencies:
     use-sync-external-store: 1.2.0
   peerDependencies:
+    "@types/react": ">=16.8"
     immer: ">=9.0"
     react: ">=16.8"
   peerDependenciesMeta:
+    "@types/react":
+      optional: true
     immer:
       optional: true
     react:
       optional: true
-  checksum: a9ceb7849ebf407d31a6121be09acfb041324f6f45ca9a3f62ab85e2d840d0f48f157abd99ed7b9e08b96ebb4e15480b4a196ed8b1df8a5a9a2ba9afd7c639a7
+  checksum: 9aeb6cc86162296c1dac504b8906ff952252c129fb3f05cc8926a7f5c9d7fbe098571d5161b3efe3347c0ee1d80197f787b768c7522721864f7323c28766717e
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Basic information

* @croz/nrich-notification-core version: v1.1.1
* @croz/nrich-form-configuration-core: v2.1.0

## Description
When using nrich-notification-core and/or nrich-form-configuration-core browser issues warnings in the console like
`[DEPRECATED] Default export is deprecated. Instead use import { create } from 'zustand'.`

### Summary
Upgrade zustand lib and its import statements to non-deprecated syntax.

### Details
The currently used zustand:4.1.4 library does not support non-deprecated syntax, so an upgrade to the latest 4.x.x version is required.

After the upgrade, the `notification-store.ts` and `form-configuration-store.ts` files are updated to use
```
import { create } from "zustand";
```
instead of

```
import create from "zustand";
```
This change prevents a browser from showing warnings.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Enhancement (non-breaking change which enhances existing functionality)
- Dependency upgrade

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass.
