### PR TITLE
Exposed notification API 'add' and 'remove' methods as non-hook function variants.

### DIFF
--- a/.changeset/loud-bees-raise.md
+++ b/.changeset/loud-bees-raise.md
@@ -1,0 +1,5 @@
+---
+"@croz/nrich-notification-core": patch
+---
+
+Exposed notification API 'add' and 'remove' methods as non-hook function variants.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,15 @@ Thank you for your interest in contributing to `nrich-frontend`. Anyone is welco
 
 As `nrich-frontend` evolves, the policies described here might change.
 
+## Opening a Pull Request
+
+To contribute to the project, the easiest way would be to fork the repository and open a cross-PR.
+
+Keep in mind that running the `changeset` script is required before merging.
+
+When opening the PR, you will get a template to fill out for easier and systematic descriptions.
+The issue resolved by the PR will be mentioned, so keep in mind to have an issue ready before opening the PR.
+
 ## Code of conduct
 
 Our [Code of conduct](./CODE_OF_CONDUCT.md) governs this project and everyone participating in it. By participating, you are expected to uphold this code.

--- a/libs/notification/core/README.md
+++ b/libs/notification/core/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-`@croz/nrich-notification-core` is a module which serves for showing automatic messages from backend on user interface.
-It's a frontend part of [nrich-notification](https://github.com/croz-ltd/nrich/tree/master/nrich-notification) backend module.
+`@croz/nrich-notification-core` is a module that is designed for showing automatic messages from the backend on the user interface.
+It's the frontend part of [nrich-notification](https://github.com/croz-ltd/nrich/tree/master/nrich-notification) backend module.
 
-Internally, it intercepts http calls and scans for sign of nrich notification object, and shows it if it exists.
+Internally, it intercepts http calls and scans for sign of nrich notification object, and shows the notification if it exists.
 
 ## Setup
 
@@ -13,11 +13,11 @@ To use this module in your project run `npm install @croz/nrich-notification-cor
 
 ## Usage
 
-1. On top level of your app, register an appropriate interceptor for notifications.
+1. On the top level of your app, register an appropriate interceptor for notifications.
    - If you use fetch API or a lib that uses fetch internally, use `fetchNotificationInterceptor()`.
-   - If you use a lib that uses `XMLHttpRequest`, eg. `axios`, use `xhrNotificationInterceptor()`.
+   - If you use a lib that uses `XMLHttpRequest`, e.g. `axios`, use `xhrNotificationInterceptor()`.
 
-2. Using  `useNotification()` custom hook you get an object containing `notifications` array and `remove` and `add` methods for working with that array.
+2. Using the `useNotification()` custom hook you get an object containing `notifications` array and `remove` and `add` methods for working with that array. Alternatively, you can use the standalone `removeNotification` and `addNotification` methods if the hook variant is not fit for your use-case.
 
 Example:
 

--- a/libs/notification/core/src/store/notification-store.ts
+++ b/libs/notification/core/src/store/notification-store.ts
@@ -46,7 +46,7 @@ export interface NotificationState {
  *
  * @returns A hook for managing notification state usable in a React environment.
  */
-export const useNotificationStore = create<NotificationState>((set) => ({
+const store = create<NotificationState>((set) => ({
   notifications: [],
   add: (notification) => set((state) => ({
     notifications: [...state.notifications, { ...notification, timestamp: new Date(notification.timestamp) || new Date() }],
@@ -55,3 +55,7 @@ export const useNotificationStore = create<NotificationState>((set) => ({
     notifications: state.notifications.filter((currentNotification) => currentNotification !== notification),
   })),
 }));
+
+export const useNotificationStore = store;
+export const addNotification = store.getState().add;
+export const removeNotification = store.getState().remove;


### PR DESCRIPTION
## Basic information

* nrich-frontend version: 3.0.1
* Module: notification

## Additional information

Resolving #62 

## Description

### Summary

Re-exported methods to satisfy naming conventions of React hooks and enable them to be used as non-hook variants.

### Details

Separated the store creation into a variable and exported as the currently used `useNotificationsStore` hook to keep compatibility. Added 2 more exports to enable the methods being available as standard (non-hook) functions.

### Related issue

#62 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

<!---
  Please, go over all the following points, and put an "x" in all the boxes that apply.

  If a point is out of scope (e.g. a change in build scripts is not required to be covered with tests),
  please remove that box, strike trough the sentence describing the point and add a short description
  as to why that point is out of scope.
  e.g.
  - ~~I have added tests to cover my changes~~ (not needed as there are only changes to build files)
-->

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] ~~I have added tests to cover my changes~~ -> the logic is unchanged, changes are semantic by nature
- [x] All new and existing tests pass.
