### PR TITLE
Add support for merging yup form configurations instead of overriding them in store

### DIFF
--- a/.changeset/angry-apes-fail.md
+++ b/.changeset/angry-apes-fail.md
@@ -1,0 +1,5 @@
+---
+"@croz/nrich-form-configuration-core": minor
+---
+
+Add support for merging yup form configurations instead of overriding them in store

--- a/libs/form-configuration/core/src/loader/fetch-form-configurations.ts
+++ b/libs/form-configuration/core/src/loader/fetch-form-configurations.ts
@@ -15,9 +15,17 @@
  *
  */
 
+import _ from "lodash";
+
 import { FormConfiguration, FormConfigurationConfiguration, FormYupConfiguration } from "../api";
 import { FormConfigurationValidationConverter } from "../converter";
 import { useFormConfigurationStore } from "../store";
+
+const mergeFormYupConfigurationsWithoutDuplicates = (oldFormYupConfiguration: FormYupConfiguration[], newFormYupConfiguration: FormYupConfiguration[]) => {
+  const mergedFormYupConfigurations = [...oldFormYupConfiguration, ...newFormYupConfiguration];
+
+  return _.uniqBy(mergedFormYupConfigurations, "formId");
+};
 
 export const fetchFormConfigurations = async ({ url, requestOptionsResolver, additionalValidatorConverters }: FormConfigurationConfiguration): Promise<FormConfiguration[]> => {
   const formConfigurationValidationConverter = new FormConfigurationValidationConverter(additionalValidatorConverters);
@@ -40,7 +48,7 @@ export const fetchFormConfigurations = async ({ url, requestOptionsResolver, add
         yupSchema: formConfigurationValidationConverter.convertFormConfigurationToYupSchema(item.constrainedPropertyConfigurationList),
       });
     });
-    useFormConfigurationStore.getState().set(formYupConfigurations);
+    useFormConfigurationStore.getState().set(mergeFormYupConfigurationsWithoutDuplicates(useFormConfigurationStore.getState().formYupConfigurations, formYupConfigurations));
     useFormConfigurationStore.getState().setFormConfigurationLoaded(true);
   }
 

--- a/libs/form-configuration/core/test/loader/fetch-form-configurations.test.ts
+++ b/libs/form-configuration/core/test/loader/fetch-form-configurations.test.ts
@@ -17,7 +17,7 @@
 
 import { fetchFormConfigurations } from "../../src/loader";
 import { useFormConfigurationStore } from "../../src/store";
-import { mockFormConfigurations, mockValidatorConverters } from "../testutil/form-configuration-generating-util";
+import { mockFormConfigurations, mockFormYupConfigurations, mockValidatorConverters } from "../testutil/form-configuration-generating-util";
 import { setupFormConfigurationServer } from "../testutil/setup-form-configuration-server";
 
 const server = setupFormConfigurationServer();
@@ -45,6 +45,26 @@ describe("@croz/nrich-form-configuration-core/fetch-form-configurations", () => 
     expect(formConfigurationState.formYupConfigurations).toHaveLength(2);
     expect(formConfigurationState.formYupConfigurations[0]).toBeTruthy();
     expect(formConfigurationState.formYupConfigurations[1]).toBeTruthy();
+
+    // cleanup
+    formConfigurationState.set([]);
+  });
+
+  it("should resolve form configurations and add them to store with ignoring duplicates", async () => {
+    // given
+    useFormConfigurationStore.getState().set([mockFormYupConfigurations[0]]);
+
+    // when
+    const response = await fetchFormConfigurations({ url: "/test-url", additionalValidatorConverters: mockValidatorConverters });
+
+    // then
+    expect(response).toHaveLength(2);
+
+    // and when
+    const formConfigurationState = useFormConfigurationStore.getState();
+
+    // then
+    expect(formConfigurationState.formYupConfigurations).toHaveLength(2);
 
     // cleanup
     formConfigurationState.set([]);


### PR DESCRIPTION
## Basic information

* nrich-frontend module version:
  3.0.1
* Module:
 form-configuration-core

## Additional information

## Description

### Summary

Add support for merging yup form configurations instead of overriding them in store

### Details

After fetching form configurations and converting them to yup form configuration, all yup form configurations in the store were overridden. With this change yup configurations will be merged instead and duplicates will be ignored.

### Related issue


## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)way)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] ~~My change requires a change to the documentation~~
- [ ] ~~I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
